### PR TITLE
Update README.md

### DIFF
--- a/Intro-to-Machine-Learning/README.md
+++ b/Intro-to-Machine-Learning/README.md
@@ -46,7 +46,7 @@ ocelote
 Now, to download the example, use:
 ```
 wget https://ua-researchcomputing-hpc.github.io/Intro-to-Machine-Learning/intro-to-ML.tar.gz
-tar xzvf intro-to-ML.tar.gz --strip-components=1
+tar xzvf intro-to-ML.tar.gz
 rm intro-to-ML.tar.gz
 ```
 


### PR DESCRIPTION
removed --strip-elements from tar command, which was causing workshop files to be thrown loose into the current directory, since no intro-to-ML directory was created.